### PR TITLE
Remove asics.com

### DIFF
--- a/emails.txt
+++ b/emails.txt
@@ -1919,7 +1919,6 @@ asianbeauty.app
 asianmeditations.ru
 asiarap.usa.cc
 asiavpn.me
-asics.com
 asicsshoes.com
 asifboot.com
 asimark.com


### PR DESCRIPTION
Removal of asics.com per https://ezcater.slack.com/archives/C94MF14JF/p1742503740000559
known good domain for customer's trying to onboard